### PR TITLE
Add parameter to republish synchronized image and camera_info

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ All parameters can be configured via `config/depth_anything_v3.param.yaml` or pa
 | `write_colormap` | bool | `false` | Save colorized debug images to disk |
 | `debug_colormap_min_depth` | double | `0.0` | Minimum depth value for colormap normalization (meters) |
 | `debug_colormap_max_depth` | double | `50.0` | Maximum depth value for colormap normalization (meters) |
+| `republish_sync_source` | bool | `false` | Enable republishing syncronized image and camera_info with which depth has been computed  |
 
 #### Available Colormaps
 `JET`, `HOT`, `COOL`, `SPRING`, `SUMMER`, `AUTUMN`, `WINTER`, `BONE`, `GRAY`, `HSV`, `PARULA`, `PLASMA`, `INFERNO`, `VIRIDIS`, `MAGMA`, `CIVIDIS`

--- a/depth_anything_v3/config/depth_anything_v3.param.yaml
+++ b/depth_anything_v3/config/depth_anything_v3.param.yaml
@@ -13,6 +13,8 @@ depth_anything_v3:
     debug_colormap_max_depth: 50.0   # Maximum depth value for colormap visualization
     sky_threshold: 0.3               # Threshold for sky classification (lower = more sky)
     sky_depth_cap: 200.0             # Maximum depth value to fill sky regions
+    republish_sync_source: false     # Republish syncronized image and camera_info from which depth has been computed
+    
     
     # Point cloud downsampling (1 = no downsampling, 10 = every 10th point)
     point_cloud_downsample_factor: 2

--- a/depth_anything_v3/include/depth_anything_v3/depth_anything_v3_node.hpp
+++ b/depth_anything_v3/include/depth_anything_v3/depth_anything_v3_node.hpp
@@ -55,6 +55,7 @@ public:
     double sky_depth_cap{};             // Cap for sky depth fill-in
     int point_cloud_downsample_factor{};  // Only publish every Nth point (1 = no downsampling)
     bool colorize_point_cloud{};  // Add RGB colors from input image to point cloud
+    bool republish_sync_source{}; // Republish source image and camera_info
   };
 
 private:
@@ -83,6 +84,8 @@ private:
   rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr pub_depth_image_;
   rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr pub_point_cloud_;
   rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr pub_depth_image_debug_;
+  rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr pub_raw_image_;
+  rclcpp::Publisher<sensor_msgs::msg::CameraInfo>::SharedPtr pub_camera_info_;
 
   // Helper methods
   int getColorMapType(const std::string& colormap_name);

--- a/depth_anything_v3/launch/depth_anything_v3.launch.py
+++ b/depth_anything_v3/launch/depth_anything_v3.launch.py
@@ -55,6 +55,18 @@ def generate_launch_description():
         description='Output point cloud topic'
     )
 
+    output_image_raw_topic_arg = DeclareLaunchArgument(
+        'output_image_raw_topic',
+        default_value='/depth_anything_v3/output/image_raw',
+        description='Output synchronized raw image topic'
+    )
+    
+    output_camera_info_topic_arg = DeclareLaunchArgument(
+        'output_camera_info_topic',
+        default_value='/depth_anything_v3/output/camera_info',
+        description='Output synchronized camera info topic'
+    )
+
     # Depth Anything V3 node
     depth_anything_v3_node = Node(
         package='depth_anything_v3',
@@ -65,7 +77,9 @@ def generate_launch_description():
             ('~/input/image', LaunchConfiguration('input_image_topic')),
             ('~/input/camera_info', LaunchConfiguration('input_camera_info_topic')),
             ('~/output/depth_image', LaunchConfiguration('output_depth_topic')),
-            ('~/output/point_cloud', LaunchConfiguration('output_point_cloud_topic'))
+            ('~/output/point_cloud', LaunchConfiguration('output_point_cloud_topic')),
+            ('~/output/image_raw', LaunchConfiguration('output_image_raw_topic')),
+            ('~/output/camera_info', LaunchConfiguration('output_camera_info_topic'))
         ],
         parameters=[LaunchConfiguration('params_file')]
     )
@@ -77,6 +91,8 @@ def generate_launch_description():
         input_camera_info_topic_arg,
         output_depth_topic_arg,
         output_point_cloud_topic_arg,
+        output_image_raw_topic_arg,
+        output_camera_info_topic_arg,
         # Nodes
         depth_anything_v3_node,
     ])

--- a/depth_anything_v3/src/depth_anything_v3_node/depth_anything_v3_node.cpp
+++ b/depth_anything_v3/src/depth_anything_v3_node/depth_anything_v3_node.cpp
@@ -111,8 +111,8 @@ DepthAnythingV3Node::DepthAnythingV3Node(const rclcpp::NodeOptions & node_option
   RCLCPP_INFO(get_logger(), "  - Camera info topic: ~/input/camera_info");
 
   // Publishers
-  pub_depth_image_ = create_publisher<sensor_msgs::msg::Image>("~/output/depth_image", 1);
-  pub_point_cloud_ = create_publisher<sensor_msgs::msg::PointCloud2>("~/output/point_cloud", 1);
+  pub_depth_image_ = create_publisher<sensor_msgs::msg::Image>("~/output/depth_image", 10);
+  pub_point_cloud_ = create_publisher<sensor_msgs::msg::PointCloud2>("~/output/point_cloud", 10);
   
   if (node_param_.enable_debug) {
     pub_depth_image_debug_ = create_publisher<sensor_msgs::msg::Image>(
@@ -120,8 +120,8 @@ DepthAnythingV3Node::DepthAnythingV3Node(const rclcpp::NodeOptions & node_option
   }
 
   if (node_param_.republish_sync_source) {
-    pub_raw_image_ = create_publisher<sensor_msgs::msg::Image>("~/output/image_raw", 1);
-    pub_camera_info_ = create_publisher<sensor_msgs::msg::CameraInfo>("~/output/camera_info", 1);
+    pub_raw_image_ = create_publisher<sensor_msgs::msg::Image>("~/output/image_raw", 10);
+    pub_camera_info_ = create_publisher<sensor_msgs::msg::CameraInfo>("~/output/camera_info", 10);
   }
 
   // Init TensorRT model

--- a/depth_anything_v3/src/depth_anything_v3_node/depth_anything_v3_node.cpp
+++ b/depth_anything_v3/src/depth_anything_v3_node/depth_anything_v3_node.cpp
@@ -72,6 +72,8 @@ DepthAnythingV3Node::DepthAnythingV3Node(const rclcpp::NodeOptions & node_option
   node_param_.debug_colormap_max_depth = declare_parameter<double>("debug_colormap_max_depth", 100.0);
   node_param_.sky_threshold = declare_parameter<double>("sky_threshold", 0.3);
   node_param_.sky_depth_cap = declare_parameter<double>("sky_depth_cap", 200.0);
+
+  node_param_.republish_sync_source = declare_parameter<bool>("republish_sync_source", false);
   
   // Point cloud parameters
   node_param_.point_cloud_downsample_factor = declare_parameter<int>("point_cloud_downsample_factor", 10);
@@ -115,6 +117,11 @@ DepthAnythingV3Node::DepthAnythingV3Node(const rclcpp::NodeOptions & node_option
   if (node_param_.enable_debug) {
     pub_depth_image_debug_ = create_publisher<sensor_msgs::msg::Image>(
       "~/output/depth_image_debug", 1);
+  }
+
+  if (node_param_.republish_sync_source) {
+    pub_raw_image_ = create_publisher<sensor_msgs::msg::Image>("~/output/image_raw", 1);
+    pub_camera_info_ = create_publisher<sensor_msgs::msg::CameraInfo>("~/output/camera_info", 1);
   }
 
   // Init TensorRT model
@@ -179,6 +186,9 @@ void DepthAnythingV3Node::onImageCameraInfo(
 
   RCLCPP_DEBUG(this->get_logger(), "Inference completed in %.3f ms", inference_time_sec * 1000.0);
 
+  // Get image header as common header
+  std_msgs::msg::Header common_header = image_msg->header;
+
   // Get depth image result
   const cv::Mat& depth_image = tensorrt_depth_anything_->getDepthImage();
   
@@ -186,12 +196,12 @@ void DepthAnythingV3Node::onImageCameraInfo(
   cv_bridge::CvImage cv_img_depth;
   cv_img_depth.image = depth_image;
   cv_img_depth.encoding = "32FC1";
-  cv_img_depth.header = image_msg->header;
+  cv_img_depth.header = common_header;
   pub_depth_image_->publish(*cv_img_depth.toImageMsg());
 
   // Publish point cloud
   sensor_msgs::msg::PointCloud2 point_cloud = tensorrt_depth_anything_->getPointCloud();
-  point_cloud.header = image_msg->header;
+  point_cloud.header = common_header;
   pub_point_cloud_->publish(point_cloud);
 
   // Publish debug depth image if enabled
@@ -250,6 +260,14 @@ void DepthAnythingV3Node::onImageCameraInfo(
     cv_img_debug.header = image_msg->header;
     pub_depth_image_debug_->publish(*cv_img_debug.toImageMsg());
   }
+
+  if (node_param_.republish_sync_source) {
+    pub_raw_image_->publish(*image_msg);
+    
+    sensor_msgs::msg::CameraInfo synced_camera_info = *camera_info_msg;
+    synced_camera_info.header = common_header;
+    pub_camera_info_->publish(synced_camera_info);
+  }
 }
 
 rcl_interfaces::msg::SetParametersResult DepthAnythingV3Node::onSetParam(
@@ -272,6 +290,7 @@ rcl_interfaces::msg::SetParametersResult DepthAnythingV3Node::onSetParam(
     update_param(params, "sky_depth_cap", p.sky_depth_cap);
     update_param(params, "point_cloud_downsample_factor", p.point_cloud_downsample_factor);
     update_param(params, "colorize_point_cloud", p.colorize_point_cloud);
+    update_param(params, "republish_sync_source", p.republish_sync_source);
     
     // Apply runtime-configurable model parameters
     if (tensorrt_depth_anything_) {


### PR DESCRIPTION
This PR introduces a new optional feature to republish the input data (`image` and `camera_info`), ensuring they share the exact same `Header` (timestamp) as the generated inference outputs (`depth_image` and `point_cloud`). 

This feature is controlled by the new boolean parameter `republish_sync_source` (defaulting to `false` to avoid overhead during standard operation).

### 🛠️ Changes Introduced
* **New Parameter:** Added `republish_sync_source` to the source code, configurable via the YAML parameter file.
* **New Publishers:** Added `~/output/image_raw` and `~/output/camera_info`.
* **QoS Tweaks:** Increased the publisher queue size (QoS history) to `10` to prevent dropping heavy messages (like PointClouds or Images) when the disk saturates during rosbag recording.
* **Launch Updates:** Updated `launch.py` to expose arguments and remappings for the new synchronized output topics.

### 💡 Why is this useful? (Key Advantages)
Although the original code already assigned the input image timestamp to the depth output, this PR solves two critical architectural issues for dataset recording and offline reprocessing environments:

#### 1. Exact Synchronization (Solving the `ApproxSync` Drift)
At the input, the node uses an `ApproximateTime` synchronizer policy to pair the image and the `CameraInfo`. This means the original `CameraInfo` might have a few milliseconds of drift compared to the image. If downstream nodes attempt to fuse the Image, Depth, and CameraInfo using a strict policy (`ExactTime`), the messages will be dropped due to this slight millisecond jitter.
**Solution:** By republishing the `CameraInfo`, we inject (or "stamp") the exact timestamp of the original image into it. This guarantees an ecosystem of 4 topics perfectly aligned down to the nanosecond.

#### 2. Massive Disk Savings in Rosbags (Filtering by True FPS)
Typically, a camera publishes at 30 FPS, but the neural network inference (Depth Anything V3) might run slower (e.g., 10 FPS). If we record the original camera topic, the rosbag will save 30 heavy images per second, out of which 20 will be "orphans" (they won't have a corresponding depth map).
**Solution:** By enabling this parameter and recording the output topics (`~/output/image_raw`), the node acts as an intelligent filter. It only publishes the original image when the inference has been successful. This drastically reduces the rosbag size (saving gigabytes of useless space) and ensures the final dataset has a perfect 1:1 ratio between images and depth maps.