### PR TITLE
Fix image transport usage and integrate docker-ros

### DIFF
--- a/.github/workflows/docker-ros.yml
+++ b/.github/workflows/docker-ros.yml
@@ -1,0 +1,28 @@
+name: docker-ros
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  docker-ros:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ika-rwth-aachen/docker-ros@main
+        with:
+          platform: amd64
+          target: dev,run
+          base-image: nvcr.io/nvidia/tensorrt:25.03-py3
+          ros-distro: jazzy
+          rmw-implementation: rmw_zenoh_cpp
+          command: ros2 launch depth_anything_v3 depth_anything_v3.launch.py
+          enable-industrial-ci: true
+        env:
+          TARGET_CMAKE_ARGS: -DCMAKE_EXPORT_COMPILE_COMMANDS=1

--- a/.github/workflows/docker-ros.yml
+++ b/.github/workflows/docker-ros.yml
@@ -23,6 +23,3 @@ jobs:
           ros-distro: jazzy
           rmw-implementation: rmw_zenoh_cpp
           command: ros2 launch depth_anything_v3 depth_anything_v3.launch.py
-          enable-industrial-ci: true
-        env:
-          TARGET_CMAKE_ARGS: -DCMAKE_EXPORT_COMPILE_COMMANDS=1

--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ Depending on your driver and CUDA version you need to select the appropriate bas
 
 All parameters can be configured via `config/depth_anything_v3.param.yaml` or passed at launch time.
 
+There is no separate `image_transport` parameter. Set the remapped image topic directly to the desired topic, including transport suffixes such as `/compressed` when needed.
+
 ### Model Configuration
 
 | Parameter | Type | Default | Description |
@@ -121,6 +123,11 @@ ros2 launch depth_anything_v3 depth_anything_v3.launch.py \
     input_camera_info_topic:=/your_camera/camera_info \
     output_depth_topic:=/depth_anything_v3/depth \
     output_point_cloud_topic:=/depth_anything_v3/points
+
+# For compressed image transport
+ros2 launch depth_anything_v3 depth_anything_v3.launch.py \
+    input_image_topic:=/your_camera/image_raw/compressed \
+    input_camera_info_topic:=/your_camera/camera_info
 ```
 
 ### With Debug Enabled

--- a/README.md
+++ b/README.md
@@ -70,8 +70,6 @@ Depending on your driver and CUDA version you need to select the appropriate bas
 
 All parameters can be configured via `config/depth_anything_v3.param.yaml` or passed at launch time.
 
-There is no separate `image_transport` parameter. Set the remapped image topic directly to the desired topic, including transport suffixes such as `/compressed` when needed.
-
 ### Model Configuration
 
 | Parameter | Type | Default | Description |
@@ -119,15 +117,10 @@ ros2 launch depth_anything_v3 depth_anything_v3.launch.py
 
 ```bash
 ros2 launch depth_anything_v3 depth_anything_v3.launch.py \
-    input_image_topic:=/your_camera/image_raw \
+    input_image_topic:=/your_camera/image \
     input_camera_info_topic:=/your_camera/camera_info \
     output_depth_topic:=/depth_anything_v3/depth \
     output_point_cloud_topic:=/depth_anything_v3/points
-
-# For compressed image transport
-ros2 launch depth_anything_v3 depth_anything_v3.launch.py \
-    input_image_topic:=/your_camera/image_raw/compressed \
-    input_camera_info_topic:=/your_camera/camera_info
 ```
 
 ### With Debug Enabled

--- a/depth_anything_v3/include/depth_anything_v3/depth_anything_v3_node.hpp
+++ b/depth_anything_v3/include/depth_anything_v3/depth_anything_v3_node.hpp
@@ -28,6 +28,7 @@
 #include <sensor_msgs/msg/point_cloud2.hpp>
 #include <string>
 #include <image_transport/subscriber_filter.hpp>
+#include <image_transport/image_transport.hpp>
 #include <message_filters/subscriber.h>
 #include <message_filters/synchronizer.h>
 #include <message_filters/sync_policies/approximate_time.h>
@@ -67,7 +68,7 @@ private:
   std::shared_ptr<message_filters::Synchronizer<ApproxSyncPolicy>> sync_;
   
   // Debug subscribers (separate from sync)
-  rclcpp::Subscription<sensor_msgs::msg::Image>::SharedPtr debug_image_sub_;
+  image_transport::SubscriberFilter debug_image_sub_;
   rclcpp::Subscription<sensor_msgs::msg::CameraInfo>::SharedPtr debug_camera_info_sub_;
 
   // Callbacks

--- a/depth_anything_v3/src/depth_anything_v3_node/depth_anything_v3_node.cpp
+++ b/depth_anything_v3/src/depth_anything_v3_node/depth_anything_v3_node.cpp
@@ -82,13 +82,36 @@ DepthAnythingV3Node::DepthAnythingV3Node(const rclcpp::NodeOptions & node_option
     node_param_.point_cloud_downsample_factor, node_param_.point_cloud_downsample_factor);
 
   RCLCPP_INFO(get_logger(), "Using model file: %s", node_param_.onnx_path.c_str());
+  RCLCPP_INFO(get_logger(), "Loaded parameters:");
+  RCLCPP_INFO(get_logger(), "  - onnx_path: %s", node_param_.onnx_path.c_str());
+  RCLCPP_INFO(get_logger(), "  - precision: %s", node_param_.precision.c_str());
+  RCLCPP_INFO(get_logger(), "  - enable_debug: %s", node_param_.enable_debug ? "true" : "false");
+  RCLCPP_INFO(get_logger(), "  - debug_colormap: %s", node_param_.debug_colormap.c_str());
+  RCLCPP_INFO(get_logger(), "  - debug_filepath: %s", node_param_.debug_filepath.c_str());
+  RCLCPP_INFO(get_logger(), "  - write_colormap: %s", node_param_.write_colormap ? "true" : "false");
+  RCLCPP_INFO(get_logger(), "  - debug_colormap_min_depth: %.3f", node_param_.debug_colormap_min_depth);
+  RCLCPP_INFO(get_logger(), "  - debug_colormap_max_depth: %.3f", node_param_.debug_colormap_max_depth);
+  RCLCPP_INFO(get_logger(), "  - sky_threshold: %.3f", node_param_.sky_threshold);
+  RCLCPP_INFO(get_logger(), "  - sky_depth_cap: %.3f", node_param_.sky_depth_cap);
+  RCLCPP_INFO(get_logger(), "  - point_cloud_downsample_factor: %d", node_param_.point_cloud_downsample_factor);
+  RCLCPP_INFO(get_logger(), "  - colorize_point_cloud: %s", node_param_.colorize_point_cloud ? "true" : "false");
 
-  // Synchronized subscribers for image (via image_transport) and camera_info
-  // image_transport supports raw and compressed transports transparently
-  const auto transport = declare_parameter<std::string>("image_transport", "raw");
-  sub_image_.subscribe(this, "~/input/image", transport, rclcpp::SensorDataQoS().get_rmw_qos_profile());
+  // Resolve the remapped image topic and infer image_transport from its suffix.
+  const std::string resolved_image_topic = this->get_node_topics_interface()->resolve_topic_name("~/input/image");
+  std::string image_base_topic = resolved_image_topic;
+  std::string image_transport = "raw";
+  std::string last_segment = resolved_image_topic.substr(resolved_image_topic.find_last_of('/') + 1);
+  if (last_segment == "compressed") {
+    image_base_topic = resolved_image_topic.substr(0, resolved_image_topic.find_last_of('/'));
+    image_transport = "compressed";
+  }
+  const auto resolved_camera_info_topic =
+    this->get_node_topics_interface()->resolve_topic_name("~/input/camera_info");
+
+  sub_image_.subscribe(
+    this, image_base_topic, image_transport, rclcpp::SensorDataQoS().get_rmw_qos_profile());
   sub_camera_info_ = std::make_shared<message_filters::Subscriber<sensor_msgs::msg::CameraInfo>>(
-    this, "~/input/camera_info", rclcpp::SensorDataQoS().get_rmw_qos_profile());
+    this, resolved_camera_info_topic, rclcpp::SensorDataQoS().get_rmw_qos_profile());
   
   // Use approximate time synchronizer with 100ms tolerance
   sync_ = std::make_shared<message_filters::Synchronizer<ApproxSyncPolicy>>(
@@ -98,17 +121,13 @@ DepthAnythingV3Node::DepthAnythingV3Node(const rclcpp::NodeOptions & node_option
   RCLCPP_INFO(get_logger(), "Using ApproximateTime synchronizer with queue size 10");
 
   // Debug subscribers to check if individual topics are arriving
-  debug_image_sub_ = this->create_subscription<sensor_msgs::msg::Image>(
-    "~/input/image", rclcpp::SensorDataQoS(),
-    std::bind(&DepthAnythingV3Node::onImageDebug, this, std::placeholders::_1));
+  debug_image_sub_.subscribe(
+    this, image_base_topic, image_transport,
+    rclcpp::SensorDataQoS().get_rmw_qos_profile());
+  debug_image_sub_.registerCallback(std::bind(&DepthAnythingV3Node::onImageDebug, this, _1));
   debug_camera_info_sub_ = this->create_subscription<sensor_msgs::msg::CameraInfo>(
-    "~/input/camera_info", rclcpp::SensorDataQoS(),
+    resolved_camera_info_topic, rclcpp::SensorDataQoS(),
     std::bind(&DepthAnythingV3Node::onCameraInfoDebug, this, std::placeholders::_1));
-
-  RCLCPP_INFO(get_logger(), "Depth Anything V3 TensorRT node initialized successfully");
-  RCLCPP_INFO(get_logger(), "Waiting for synchronized messages on:");
-  RCLCPP_INFO(get_logger(), "  - Image topic: ~/input/image");
-  RCLCPP_INFO(get_logger(), "  - Camera info topic: ~/input/camera_info");
 
   // Publishers
   pub_depth_image_ = create_publisher<sensor_msgs::msg::Image>("~/output/depth_image", 1);
@@ -117,6 +136,27 @@ DepthAnythingV3Node::DepthAnythingV3Node(const rclcpp::NodeOptions & node_option
   if (node_param_.enable_debug) {
     pub_depth_image_debug_ = create_publisher<sensor_msgs::msg::Image>(
       "~/output/depth_image_debug", 1);
+  }
+
+  const auto resolved_depth_topic =
+    this->get_node_topics_interface()->resolve_topic_name("~/output/depth_image");
+  const auto resolved_point_cloud_topic =
+    this->get_node_topics_interface()->resolve_topic_name("~/output/point_cloud");
+  const auto resolved_debug_depth_topic = node_param_.enable_debug ?
+    this->get_node_topics_interface()->resolve_topic_name("~/output/depth_image_debug") :
+    std::string{};
+
+  RCLCPP_INFO(get_logger(), "Depth Anything V3 TensorRT node initialized successfully");
+  RCLCPP_INFO(get_logger(), "Subscribed topics:");
+  RCLCPP_INFO(
+    get_logger(), "  - image (sync/debug): %s [transport=%s, base=%s]",
+    resolved_image_topic.c_str(), image_transport.c_str(), image_base_topic.c_str());
+  RCLCPP_INFO(get_logger(), "  - camera_info (sync/debug): %s", resolved_camera_info_topic.c_str());
+  RCLCPP_INFO(get_logger(), "Published topics:");
+  RCLCPP_INFO(get_logger(), "  - depth_image: %s", resolved_depth_topic.c_str());
+  RCLCPP_INFO(get_logger(), "  - point_cloud: %s", resolved_point_cloud_topic.c_str());
+  if (node_param_.enable_debug) {
+    RCLCPP_INFO(get_logger(), "  - depth_image_debug: %s", resolved_debug_depth_topic.c_str());
   }
 
   // Init TensorRT model

--- a/depth_anything_v3/src/depth_anything_v3_node/depth_anything_v3_node.cpp
+++ b/depth_anything_v3/src/depth_anything_v3_node/depth_anything_v3_node.cpp
@@ -82,19 +82,6 @@ DepthAnythingV3Node::DepthAnythingV3Node(const rclcpp::NodeOptions & node_option
     node_param_.point_cloud_downsample_factor, node_param_.point_cloud_downsample_factor);
 
   RCLCPP_INFO(get_logger(), "Using model file: %s", node_param_.onnx_path.c_str());
-  RCLCPP_INFO(get_logger(), "Loaded parameters:");
-  RCLCPP_INFO(get_logger(), "  - onnx_path: %s", node_param_.onnx_path.c_str());
-  RCLCPP_INFO(get_logger(), "  - precision: %s", node_param_.precision.c_str());
-  RCLCPP_INFO(get_logger(), "  - enable_debug: %s", node_param_.enable_debug ? "true" : "false");
-  RCLCPP_INFO(get_logger(), "  - debug_colormap: %s", node_param_.debug_colormap.c_str());
-  RCLCPP_INFO(get_logger(), "  - debug_filepath: %s", node_param_.debug_filepath.c_str());
-  RCLCPP_INFO(get_logger(), "  - write_colormap: %s", node_param_.write_colormap ? "true" : "false");
-  RCLCPP_INFO(get_logger(), "  - debug_colormap_min_depth: %.3f", node_param_.debug_colormap_min_depth);
-  RCLCPP_INFO(get_logger(), "  - debug_colormap_max_depth: %.3f", node_param_.debug_colormap_max_depth);
-  RCLCPP_INFO(get_logger(), "  - sky_threshold: %.3f", node_param_.sky_threshold);
-  RCLCPP_INFO(get_logger(), "  - sky_depth_cap: %.3f", node_param_.sky_depth_cap);
-  RCLCPP_INFO(get_logger(), "  - point_cloud_downsample_factor: %d", node_param_.point_cloud_downsample_factor);
-  RCLCPP_INFO(get_logger(), "  - colorize_point_cloud: %s", node_param_.colorize_point_cloud ? "true" : "false");
 
   // Resolve the remapped image topic and infer image_transport from its suffix.
   const std::string resolved_image_topic = this->get_node_topics_interface()->resolve_topic_name("~/input/image");
@@ -105,8 +92,7 @@ DepthAnythingV3Node::DepthAnythingV3Node(const rclcpp::NodeOptions & node_option
     image_base_topic = resolved_image_topic.substr(0, resolved_image_topic.find_last_of('/'));
     image_transport = "compressed";
   }
-  const auto resolved_camera_info_topic =
-    this->get_node_topics_interface()->resolve_topic_name("~/input/camera_info");
+  const auto resolved_camera_info_topic = this->get_node_topics_interface()->resolve_topic_name("~/input/camera_info");
 
   sub_image_.subscribe(
     this, image_base_topic, image_transport, rclcpp::SensorDataQoS().get_rmw_qos_profile());
@@ -138,19 +124,16 @@ DepthAnythingV3Node::DepthAnythingV3Node(const rclcpp::NodeOptions & node_option
       "~/output/depth_image_debug", 1);
   }
 
-  const auto resolved_depth_topic =
-    this->get_node_topics_interface()->resolve_topic_name("~/output/depth_image");
-  const auto resolved_point_cloud_topic =
-    this->get_node_topics_interface()->resolve_topic_name("~/output/point_cloud");
+  const auto resolved_depth_topic = this->get_node_topics_interface()->resolve_topic_name("~/output/depth_image");
+  const auto resolved_point_cloud_topic = this->get_node_topics_interface()->resolve_topic_name("~/output/point_cloud");
   const auto resolved_debug_depth_topic = node_param_.enable_debug ?
     this->get_node_topics_interface()->resolve_topic_name("~/output/depth_image_debug") :
     std::string{};
 
   RCLCPP_INFO(get_logger(), "Depth Anything V3 TensorRT node initialized successfully");
   RCLCPP_INFO(get_logger(), "Subscribed topics:");
-  RCLCPP_INFO(
-    get_logger(), "  - image (sync/debug): %s [transport=%s, base=%s]",
-    resolved_image_topic.c_str(), image_transport.c_str(), image_base_topic.c_str());
+  RCLCPP_INFO(get_logger(), "  - image (sync/debug): %s [transport=%s, base=%s]",
+              resolved_image_topic.c_str(), image_transport.c_str(), image_base_topic.c_str());
   RCLCPP_INFO(get_logger(), "  - camera_info (sync/debug): %s", resolved_camera_info_topic.c_str());
   RCLCPP_INFO(get_logger(), "Published topics:");
   RCLCPP_INFO(get_logger(), "  - depth_image: %s", resolved_depth_topic.c_str());


### PR DESCRIPTION
The image transport subscriber is now initialized correctly by automatically determining the transport type from the remapped topic. Additionally, logging has been added to clearly show the loaded parameters and resolved remapped topics. Furthermore a docker-ros pipeline has been integrated to automatically build the corresponding docker images.