### PR TITLE
Move pre- and postprocessing to the GPU (+29% throughput)

### DIFF
--- a/depth_anything_v3/CMakeLists.txt
+++ b/depth_anything_v3/CMakeLists.txt
@@ -67,6 +67,7 @@ include_directories(
 
 # Create TensorRT depth inference library
 add_library(tensorrt_depth_anything SHARED
+  src/tensorrt_depth_anything/preprocess_gpu.cu
   src/tensorrt_depth_anything/tensorrt_depth_anything.cpp
   src/tensorrt_common/tensorrt_common.cpp
   src/tensorrt_common/simple_profiler.cpp

--- a/depth_anything_v3/CMakeLists.txt
+++ b/depth_anything_v3/CMakeLists.txt
@@ -68,6 +68,7 @@ include_directories(
 # Create TensorRT depth inference library
 add_library(tensorrt_depth_anything SHARED
   src/tensorrt_depth_anything/preprocess_gpu.cu
+  src/tensorrt_depth_anything/postprocess_gpu.cu
   src/tensorrt_depth_anything/tensorrt_depth_anything.cpp
   src/tensorrt_common/tensorrt_common.cpp
   src/tensorrt_common/simple_profiler.cpp

--- a/depth_anything_v3/include/depth_anything_v3/depth_anything_v3_node.hpp
+++ b/depth_anything_v3/include/depth_anything_v3/depth_anything_v3_node.hpp
@@ -67,8 +67,7 @@ private:
   typedef message_filters::sync_policies::ApproximateTime<sensor_msgs::msg::Image, sensor_msgs::msg::CameraInfo> ApproxSyncPolicy;
   std::shared_ptr<message_filters::Synchronizer<ApproxSyncPolicy>> sync_;
   
-  // Debug subscribers (separate from sync)
-  image_transport::SubscriberFilter debug_image_sub_;
+  // Debug subscriber (separate from sync)
   rclcpp::Subscription<sensor_msgs::msg::CameraInfo>::SharedPtr debug_camera_info_sub_;
 
   // Callbacks

--- a/depth_anything_v3/include/depth_anything_v3/tensorrt_depth_anything.hpp
+++ b/depth_anything_v3/include/depth_anything_v3/tensorrt_depth_anything.hpp
@@ -15,9 +15,10 @@
 #ifndef DEPTH_ANYTHING_V3__TENSORRT_DEPTH_ANYTHING_HPP_
 #define DEPTH_ANYTHING_V3__TENSORRT_DEPTH_ANYTHING_HPP_
 
+#include <cstdint>
+
 #include <cuda_utils/cuda_unique_ptr.hpp>
 #include <cuda_utils/stream_unique_ptr.hpp>
-#include <cstdint>
 #include <memory>
 #include <opencv2/opencv.hpp>
 #include <string>
@@ -37,6 +38,15 @@ using cuda_utils::StreamUniquePtr;
 void launchPreprocess(
   const uint8_t * src_bgr, int src_width, int src_height,
   float * dst_nchw, int dst_width, int dst_height, cudaStream_t stream);
+
+// Defined in postprocess_gpu.cu
+size_t postprocessScratchBytes(int num_pixels);
+void launchPostprocess(
+  const float * depth_raw, const float * sky_raw, int width, int height,
+  float focal_scale, float sky_threshold, float sky_depth_cap,
+  int out_width, int out_height,
+  float * depth_out, uint8_t * mask_out, float * depth_full_out,
+  void * scratch_buffer, size_t scratch_bytes, cudaStream_t stream);
 
 /**
  * @class TensorRTDepthAnything
@@ -111,6 +121,15 @@ private:
   void postprocess(const sensor_msgs::msg::CameraInfo & camera_info, int downsample_factor = 1, const cv::Mat & rgb_image = cv::Mat());
 
   /**
+   * @brief (re)allocate the postprocessing buffers when the resolution changes
+   * @param[in] width network output width
+   * @param[in] height network output height
+   * @param[in] out_width published depth image width
+   * @param[in] out_height published depth image height
+   */
+  void initPostprocessBuffers(int width, int height, int out_width, int out_height);
+
+  /**
    * @brief Build point cloud from depth image using camera intrinsics
    * @param[in] camera_info camera calibration parameters
    * @param[in] downsample_factor only publish every Nth point
@@ -129,11 +148,9 @@ public:
 
   // Output buffer for predicted depth
   CudaUniquePtr<float[]> depth_d_;
-  CudaUniquePtrHost<float[]> depth_h_;
   size_t depth_elem_num_{};
   // Output buffer for predicted sky
   CudaUniquePtr<float[]> sky_d_;
-  CudaUniquePtrHost<float[]> sky_h_;
   size_t sky_elem_num_{};
   std::vector<CudaUniquePtr<float[]>> extra_output_buffers_;
   cv::Mat model_depth_;
@@ -148,6 +165,17 @@ public:
   CudaUniquePtrHost<unsigned char[]> image_buf_h_;
   CudaUniquePtr<unsigned char[]> image_buf_d_;
   size_t image_buf_bytes_{0};
+
+  // postprocessing buffers, allocated for the current input/output size
+  CudaUniquePtr<float[]> depth_scaled_d_;
+  CudaUniquePtr<float[]> depth_full_d_;
+  CudaUniquePtr<uint8_t[]> sky_mask_d_;
+  CudaUniquePtr<uint8_t[]> post_scratch_d_;
+  size_t post_scratch_bytes_{0};
+  int post_width_{0};
+  int post_height_{0};
+  int post_out_width_{0};
+  int post_out_height_{0};
 
   int src_width_;
   int src_height_;

--- a/depth_anything_v3/include/depth_anything_v3/tensorrt_depth_anything.hpp
+++ b/depth_anything_v3/include/depth_anything_v3/tensorrt_depth_anything.hpp
@@ -17,6 +17,7 @@
 
 #include <cuda_utils/cuda_unique_ptr.hpp>
 #include <cuda_utils/stream_unique_ptr.hpp>
+#include <cstdint>
 #include <memory>
 #include <opencv2/opencv.hpp>
 #include <string>
@@ -31,6 +32,11 @@ using cuda_utils::CudaUniquePtr;
 using cuda_utils::CudaUniquePtrHost;
 using cuda_utils::makeCudaStream;
 using cuda_utils::StreamUniquePtr;
+
+// Defined in preprocess_gpu.cu
+void launchPreprocess(
+  const uint8_t * src_bgr, int src_width, int src_height,
+  float * dst_nchw, int dst_width, int dst_height, cudaStream_t stream);
 
 /**
  * @class TensorRTDepthAnything
@@ -86,7 +92,7 @@ public:
 
 private:
   /**
-   * @brief run preprocess including resizing, letterbox, NHWC2NCHW and toFloat on CPU
+   * @brief run preprocess including resizing, NHWC2NCHW and toFloat on GPU
    * @param[in] images batching images
    */
   void preprocess(const std::vector<cv::Mat> & images);
@@ -119,7 +125,6 @@ public:
   std::unique_ptr<tensorrt_common::TrtCommon> trt_common_;
 
   // Input/output buffers
-  std::vector<float> input_h_;
   CudaUniquePtr<float[]> input_d_;
 
   // Output buffer for predicted depth
@@ -142,6 +147,7 @@ public:
   bool use_gpu_preprocess_;
   CudaUniquePtrHost<unsigned char[]> image_buf_h_;
   CudaUniquePtr<unsigned char[]> image_buf_d_;
+  size_t image_buf_bytes_{0};
 
   int src_width_;
   int src_height_;

--- a/depth_anything_v3/src/depth_anything_v3_node/depth_anything_v3_node.cpp
+++ b/depth_anything_v3/src/depth_anything_v3_node/depth_anything_v3_node.cpp
@@ -106,11 +106,9 @@ DepthAnythingV3Node::DepthAnythingV3Node(const rclcpp::NodeOptions & node_option
   
   RCLCPP_INFO(get_logger(), "Using ApproximateTime synchronizer with queue size 10");
 
-  // Debug subscribers to check if individual topics are arriving
-  debug_image_sub_.subscribe(
-    this, image_base_topic, image_transport,
-    rclcpp::SensorDataQoS().get_rmw_qos_profile());
-  debug_image_sub_.registerCallback(std::bind(&DepthAnythingV3Node::onImageDebug, this, _1));
+  // Debug callbacks to check if individual topics are arriving. The image one
+  // registers on sub_image_; a second subscription would decode every frame again.
+  sub_image_.registerCallback(std::bind(&DepthAnythingV3Node::onImageDebug, this, _1));
   debug_camera_info_sub_ = this->create_subscription<sensor_msgs::msg::CameraInfo>(
     resolved_camera_info_topic, rclcpp::SensorDataQoS(),
     std::bind(&DepthAnythingV3Node::onCameraInfoDebug, this, std::placeholders::_1));

--- a/depth_anything_v3/src/depth_anything_v3_node/depth_anything_v3_node.cpp
+++ b/depth_anything_v3/src/depth_anything_v3_node/depth_anything_v3_node.cpp
@@ -169,9 +169,9 @@ void DepthAnythingV3Node::onImageCameraInfo(
   const sensor_msgs::msg::CameraInfo::ConstSharedPtr & camera_info_msg)
 {
 
-  cv_bridge::CvImagePtr in_image_ptr;
+  cv_bridge::CvImageConstPtr in_image_ptr;
   try {
-    in_image_ptr = cv_bridge::toCvCopy(image_msg, sensor_msgs::image_encodings::BGR8);
+    in_image_ptr = cv_bridge::toCvShare(image_msg, sensor_msgs::image_encodings::BGR8);
   } catch (cv_bridge::Exception & e) {
     RCLCPP_ERROR(this->get_logger(), "cv_bridge exception: %s", e.what());
     return;

--- a/depth_anything_v3/src/tensorrt_depth_anything/postprocess_gpu.cu
+++ b/depth_anything_v3/src/tensorrt_depth_anything/postprocess_gpu.cu
@@ -1,0 +1,288 @@
+// Copyright 2025 Institute for Automotive Engineering (ika), RWTH Aachen University
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <cub/cub.cuh>
+#include <cuda_runtime.h>
+
+#include <cstdint>
+#include <stdexcept>
+
+#include "cuda_utils/cuda_check_error.hpp"
+
+namespace depth_anything_v3
+{
+namespace
+{
+constexpr int kBlockSize = 256;
+constexpr int kHistogramBins = 4096;
+constexpr uint32_t kMaxSample = 100000;
+constexpr size_t kScratchAlignment = 256;
+
+// Device scratch for one postprocess call, carved out of a single buffer.
+struct Scratch
+{
+  uint32_t * valid;        // 1 for the pixels that feed the percentile
+  uint32_t * rank;         // exclusive prefix sum of valid
+  uint32_t * histogram;
+  uint32_t * range_lo;     // depth range of the sampled pixels, as float bits
+  uint32_t * range_hi;
+  uint32_t * sample_size;  // number of pixels the percentile is taken over
+  float * fill;            // depth written to the sky pixels
+  void * scan;
+  size_t scan_bytes;
+  size_t total_bytes;
+};
+
+// With base == nullptr this only computes total_bytes.
+Scratch layoutScratch(int num_pixels, void * base)
+{
+  Scratch scratch{};
+  CHECK_CUDA_ERROR(cub::DeviceScan::ExclusiveSum(
+    nullptr, scratch.scan_bytes, static_cast<uint32_t *>(nullptr),
+    static_cast<uint32_t *>(nullptr), num_pixels));
+
+  auto * bytes = static_cast<uint8_t *>(base);
+  size_t offset = 0;
+  const auto take = [&](size_t size) -> void * {
+    void * ptr = bytes != nullptr ? bytes + offset : nullptr;
+    offset += (size + kScratchAlignment - 1) / kScratchAlignment * kScratchAlignment;
+    return ptr;
+  };
+
+  const size_t counts_bytes = static_cast<size_t>(num_pixels) * sizeof(uint32_t);
+  scratch.valid = static_cast<uint32_t *>(take(counts_bytes));
+  scratch.rank = static_cast<uint32_t *>(take(counts_bytes));
+  scratch.histogram = static_cast<uint32_t *>(take(kHistogramBins * sizeof(uint32_t)));
+  scratch.range_lo = static_cast<uint32_t *>(take(sizeof(uint32_t)));
+  scratch.range_hi = static_cast<uint32_t *>(take(sizeof(uint32_t)));
+  scratch.sample_size = static_cast<uint32_t *>(take(sizeof(uint32_t)));
+  scratch.fill = static_cast<float *>(take(sizeof(float)));
+  scratch.scan = take(scratch.scan_bytes);
+  scratch.total_bytes = offset;
+  return scratch;
+}
+
+// The mask selects the non-sky pixels, which are the ones kept in the point
+// cloud. The percentile additionally skips non-finite and non-positive depths.
+__global__ void scaleAndMask(
+  const float * __restrict__ raw, const float * __restrict__ sky,
+  float sky_threshold, float focal_scale, float * __restrict__ depth,
+  uint8_t * __restrict__ mask, uint32_t * __restrict__ valid, int num_pixels)
+{
+  const int i = blockIdx.x * blockDim.x + threadIdx.x;
+  if (i >= num_pixels) return;
+
+  float scaled = raw[i];
+  if (scaled <= 0.0f) scaled = 0.0f;
+  scaled *= focal_scale;
+
+  const bool non_sky = sky[i] < sky_threshold;
+  depth[i] = scaled;
+  mask[i] = non_sky ? 1u : 0u;
+  valid[i] = non_sky && isfinite(scaled) && scaled > 0.0f ? 1u : 0u;
+}
+
+// The sample is the first kMaxSample valid pixels in row-major order, not a
+// subsample spread over the frame; the sky fill value is calibrated against it.
+__global__ void countSample(
+  const uint32_t * __restrict__ rank, const uint32_t * __restrict__ valid,
+  uint32_t * __restrict__ sample_size, int num_pixels)
+{
+  const uint32_t total = rank[num_pixels - 1] + valid[num_pixels - 1];
+  *sample_size = total < kMaxSample ? total : kMaxSample;
+}
+
+// Depths are non-negative, so their IEEE bit patterns compare in the same order
+// and integer atomics can be used. Reducing within the block first keeps the
+// number of atomics on the two global words down to one per block.
+__global__ void reduceRange(
+  const float * __restrict__ depth, const uint32_t * __restrict__ valid,
+  const uint32_t * __restrict__ rank, const uint32_t * __restrict__ sample_size,
+  uint32_t * __restrict__ range_lo, uint32_t * __restrict__ range_hi, int num_pixels)
+{
+  __shared__ uint32_t block_lo;
+  __shared__ uint32_t block_hi;
+  if (threadIdx.x == 0) {
+    block_lo = 0xFFFFFFFFu;
+    block_hi = 0u;
+  }
+  __syncthreads();
+
+  const int i = blockIdx.x * blockDim.x + threadIdx.x;
+  if (i < num_pixels && valid[i] != 0u && rank[i] < *sample_size) {
+    const uint32_t bits = __float_as_uint(depth[i]);
+    atomicMin(&block_lo, bits);
+    atomicMax(&block_hi, bits);
+  }
+  __syncthreads();
+
+  if (threadIdx.x == 0) {
+    atomicMin(range_lo, block_lo);
+    atomicMax(range_hi, block_hi);
+  }
+}
+
+__global__ void histogramSample(
+  const float * __restrict__ depth, const uint32_t * __restrict__ valid,
+  const uint32_t * __restrict__ rank, const uint32_t * __restrict__ sample_size,
+  const uint32_t * __restrict__ range_lo, const uint32_t * __restrict__ range_hi,
+  uint32_t * __restrict__ histogram, int num_pixels)
+{
+  const int i = blockIdx.x * blockDim.x + threadIdx.x;
+  if (i >= num_pixels || valid[i] == 0u || rank[i] >= *sample_size) return;
+
+  const float lo = __uint_as_float(*range_lo);
+  const float hi = __uint_as_float(*range_hi);
+  if (hi <= lo) return;
+
+  const float bin_scale = (kHistogramBins - 1) / (hi - lo);
+  atomicAdd(&histogram[static_cast<int>((depth[i] - lo) * bin_scale)], 1u);
+}
+
+// One thread walks the bins so the fill value stays on the device and the
+// pipeline never has to synchronise in the middle of the postprocess.
+__global__ void pickFillValue(
+  const uint32_t * __restrict__ histogram, const uint32_t * __restrict__ sample_size,
+  const uint32_t * __restrict__ range_lo, const uint32_t * __restrict__ range_hi,
+  float sky_depth_cap, float * __restrict__ fill)
+{
+  const uint32_t size = *sample_size;
+  if (size == 0u) return;
+
+  const float lo = __uint_as_float(*range_lo);
+  const float hi = __uint_as_float(*range_hi);
+  if (hi <= lo) {
+    *fill = fminf(lo, sky_depth_cap);
+    return;
+  }
+
+  const uint32_t target = static_cast<uint32_t>(0.99 * (size - 1));
+  uint32_t cumulative = 0u;
+  int bin = 0;
+  for (; bin < kHistogramBins; ++bin) {
+    cumulative += histogram[bin];
+    if (cumulative > target) break;
+  }
+  const float bin_scale = (kHistogramBins - 1) / (hi - lo);
+  *fill = fminf(lo + static_cast<float>(bin) / bin_scale, sky_depth_cap);
+}
+
+// With no valid pixels there is no fill value and the sky is left as it is.
+__global__ void fillSky(
+  float * __restrict__ depth, const uint8_t * __restrict__ mask,
+  const uint32_t * __restrict__ sample_size, const float * __restrict__ fill, int num_pixels)
+{
+  const int i = blockIdx.x * blockDim.x + threadIdx.x;
+  if (i >= num_pixels || *sample_size == 0u || mask[i] != 0u) return;
+  depth[i] = *fill;
+}
+
+__device__ __forceinline__ void cubicCoeffs(float t, float * c)
+{
+  const float A = -0.75f;
+  c[0] = ((A * (t + 1) - 5 * A) * (t + 1) + 8 * A) * (t + 1) - 4 * A;
+  c[1] = ((A + 2) * t - (A + 3)) * t * t + 1;
+  c[2] = ((A + 2) * (1 - t) - (A + 3)) * (1 - t) * (1 - t) + 1;
+  c[3] = 1.0f - c[0] - c[1] - c[2];
+}
+
+// Float bicubic upscale. There is no saturating cast here: cv::resize on CV_32F
+// keeps the interpolated value, overshoot included.
+__global__ void upscaleCubic(
+  const float * __restrict__ src, int src_width, int src_height,
+  float * __restrict__ dst, int dst_width, int dst_height)
+{
+  const int x = blockIdx.x * blockDim.x + threadIdx.x;
+  const int y = blockIdx.y * blockDim.y + threadIdx.y;
+  if (x >= dst_width || y >= dst_height) return;
+
+  const float fx = (x + 0.5f) * src_width / dst_width - 0.5f;
+  const float fy = (y + 0.5f) * src_height / dst_height - 0.5f;
+  const int ix = __float2int_rd(fx);
+  const int iy = __float2int_rd(fy);
+
+  float cx[4], cy[4];
+  cubicCoeffs(fx - ix, cx);
+  cubicCoeffs(fy - iy, cy);
+
+  float acc = 0.0f;
+  for (int m = 0; m < 4; ++m) {
+    const int sy = min(max(iy - 1 + m, 0), src_height - 1);
+    float row = 0.0f;
+    for (int k = 0; k < 4; ++k) {
+      const int sx = min(max(ix - 1 + k, 0), src_width - 1);
+      row += cx[k] * src[sy * src_width + sx];
+    }
+    acc += cy[m] * row;
+  }
+  dst[y * dst_width + x] = acc;
+}
+}  // namespace
+
+size_t postprocessScratchBytes(int num_pixels)
+{
+  return layoutScratch(num_pixels, nullptr).total_bytes;
+}
+
+void launchPostprocess(
+  const float * depth_raw, const float * sky_raw, int width, int height,
+  float focal_scale, float sky_threshold, float sky_depth_cap,
+  int out_width, int out_height,
+  float * depth_out, uint8_t * mask_out, float * depth_full_out,
+  void * scratch_buffer, size_t scratch_bytes, cudaStream_t stream)
+{
+  const int num_pixels = width * height;
+  const Scratch scratch = layoutScratch(num_pixels, scratch_buffer);
+  if (scratch_bytes < scratch.total_bytes) {
+    throw std::runtime_error("postprocess scratch buffer is too small");
+  }
+  const int blocks = (num_pixels + kBlockSize - 1) / kBlockSize;
+
+  scaleAndMask<<<blocks, kBlockSize, 0, stream>>>(
+    depth_raw, sky_raw, sky_threshold, focal_scale,
+    depth_out, mask_out, scratch.valid, num_pixels);
+
+  // rank[i] is the number of valid pixels before i, so taking the first N in
+  // row-major order is just rank < N.
+  size_t scan_bytes = scratch.scan_bytes;
+  CHECK_CUDA_ERROR(cub::DeviceScan::ExclusiveSum(
+    scratch.scan, scan_bytes, scratch.valid, scratch.rank, num_pixels, stream));
+  countSample<<<1, 1, 0, stream>>>(scratch.rank, scratch.valid, scratch.sample_size, num_pixels);
+
+  CHECK_CUDA_ERROR(cudaMemsetAsync(scratch.range_lo, 0xFF, sizeof(uint32_t), stream));
+  CHECK_CUDA_ERROR(cudaMemsetAsync(scratch.range_hi, 0x00, sizeof(uint32_t), stream));
+  CHECK_CUDA_ERROR(
+    cudaMemsetAsync(scratch.histogram, 0, kHistogramBins * sizeof(uint32_t), stream));
+
+  reduceRange<<<blocks, kBlockSize, 0, stream>>>(
+    depth_out, scratch.valid, scratch.rank, scratch.sample_size,
+    scratch.range_lo, scratch.range_hi, num_pixels);
+  histogramSample<<<blocks, kBlockSize, 0, stream>>>(
+    depth_out, scratch.valid, scratch.rank, scratch.sample_size,
+    scratch.range_lo, scratch.range_hi, scratch.histogram, num_pixels);
+  pickFillValue<<<1, 1, 0, stream>>>(
+    scratch.histogram, scratch.sample_size, scratch.range_lo, scratch.range_hi,
+    sky_depth_cap, scratch.fill);
+  fillSky<<<blocks, kBlockSize, 0, stream>>>(
+    depth_out, mask_out, scratch.sample_size, scratch.fill, num_pixels);
+
+  const dim3 block(16, 16);
+  const dim3 grid((out_width + block.x - 1) / block.x, (out_height + block.y - 1) / block.y);
+  upscaleCubic<<<grid, block, 0, stream>>>(
+    depth_out, width, height, depth_full_out, out_width, out_height);
+
+  CHECK_CUDA_ERROR(cudaGetLastError());
+}
+
+}  // namespace depth_anything_v3

--- a/depth_anything_v3/src/tensorrt_depth_anything/preprocess_gpu.cu
+++ b/depth_anything_v3/src/tensorrt_depth_anything/preprocess_gpu.cu
@@ -1,0 +1,94 @@
+// Copyright 2025 Institute for Automotive Engineering (ika), RWTH Aachen University
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <cuda_runtime.h>
+
+#include <cstdint>
+
+#include "cuda_utils/cuda_check_error.hpp"
+
+namespace depth_anything_v3
+{
+namespace
+{
+__constant__ float c_mean[3] = {0.485f, 0.456f, 0.406f};
+__constant__ float c_inv_std[3] = {1.0f / 0.229f, 1.0f / 0.224f, 1.0f / 0.225f};
+
+// Cubic convolution weights with A = -0.75, as used by cv::INTER_CUBIC. A
+// bilinear substitute is much cheaper but moves the published depth by tens of
+// metres, so the filter is reproduced rather than approximated.
+__device__ __forceinline__ void cubicCoeffs(float t, float * c)
+{
+  const float A = -0.75f;
+  c[0] = ((A * (t + 1) - 5 * A) * (t + 1) + 8 * A) * (t + 1) - 4 * A;
+  c[1] = ((A + 2) * t - (A + 3)) * t * t + 1;
+  c[2] = ((A + 2) * (1 - t) - (A + 3)) * (1 - t) * (1 - t) + 1;
+  c[3] = 1.0f - c[0] - c[1] - c[2];
+}
+
+// Resize, BGR to RGB, ImageNet normalisation and NCHW packing in one pass.
+__global__ void resizeCubicNormalizeNCHW(
+  const uchar3 * __restrict__ src, int src_width, int src_height,
+  float * __restrict__ dst, int dst_width, int dst_height)
+{
+  const int x = blockIdx.x * blockDim.x + threadIdx.x;
+  const int y = blockIdx.y * blockDim.y + threadIdx.y;
+  if (x >= dst_width || y >= dst_height) return;
+
+  const float fx = (x + 0.5f) * src_width / dst_width - 0.5f;
+  const float fy = (y + 0.5f) * src_height / dst_height - 0.5f;
+  const int ix = __float2int_rd(fx);
+  const int iy = __float2int_rd(fy);
+
+  float cx[4], cy[4];
+  cubicCoeffs(fx - ix, cx);
+  cubicCoeffs(fy - iy, cy);
+
+  float acc[3] = {0.0f, 0.0f, 0.0f};
+  for (int m = 0; m < 4; ++m) {
+    const int sy = min(max(iy - 1 + m, 0), src_height - 1);
+    float row[3] = {0.0f, 0.0f, 0.0f};
+    for (int k = 0; k < 4; ++k) {
+      const int sx = min(max(ix - 1 + k, 0), src_width - 1);
+      const uchar3 pixel = src[sy * src_width + sx];
+      row[0] += cx[k] * pixel.z;
+      row[1] += cx[k] * pixel.y;
+      row[2] += cx[k] * pixel.x;
+    }
+    for (int c = 0; c < 3; ++c) acc[c] += cy[m] * row[c];
+  }
+
+  const int plane_size = dst_width * dst_height;
+  const int i = y * dst_width + x;
+  for (int c = 0; c < 3; ++c) {
+    // cv::resize rounds and saturates back to 8U before the normalisation.
+    const float value = fminf(fmaxf(rintf(acc[c]), 0.0f), 255.0f);
+    dst[c * plane_size + i] = (value * (1.0f / 255.0f) - c_mean[c]) * c_inv_std[c];
+  }
+}
+}  // namespace
+
+void launchPreprocess(
+  const uint8_t * src_bgr, int src_width, int src_height,
+  float * dst_nchw, int dst_width, int dst_height, cudaStream_t stream)
+{
+  const dim3 block(16, 16);
+  const dim3 grid((dst_width + block.x - 1) / block.x, (dst_height + block.y - 1) / block.y);
+  resizeCubicNormalizeNCHW<<<grid, block, 0, stream>>>(
+    reinterpret_cast<const uchar3 *>(src_bgr), src_width, src_height,
+    dst_nchw, dst_width, dst_height);
+  CHECK_CUDA_ERROR(cudaGetLastError());
+}
+
+}  // namespace depth_anything_v3

--- a/depth_anything_v3/src/tensorrt_depth_anything/tensorrt_depth_anything.cpp
+++ b/depth_anything_v3/src/tensorrt_depth_anything/tensorrt_depth_anything.cpp
@@ -261,34 +261,23 @@ void TensorRTDepthAnything::preprocess(const std::vector<cv::Mat> & images)
   }
 
   const size_t volume = batch_size * input_chan * input_height_ * input_width_;
-  input_h_.assign(volume, 0.0f);
+  input_h_.resize(volume);
 
-  const std::vector<float> mean{0.485f, 0.456f, 0.406f};
-  const std::vector<float> std_vals{0.229f, 0.224f, 0.225f};
+  const float mean[3] = {0.485f, 0.456f, 0.406f};
+  const float std_vals[3] = {0.229f, 0.224f, 0.225f};
 
-  const size_t strides_cv[4] = {
-    static_cast<size_t>(input_width_ * input_chan * input_height_),
-    static_cast<size_t>(input_width_ * input_chan),
-    static_cast<size_t>(input_chan), 1};
-  const size_t strides[4] = {
-    static_cast<size_t>(input_height_ * input_width_ * input_chan),
-    static_cast<size_t>(input_height_ * input_width_),
-    static_cast<size_t>(input_width_), 1};
-
+  // (v/255 - mean) / std  folded into convertTo's alpha/beta, per plane.
+  // cv::split gives B,G,R so destination channel c reads plane (chan-1-c).
+  const size_t plane = static_cast<size_t>(input_height_) * input_width_;
+  std::vector<cv::Mat> src_planes;
   for (size_t n = 0; n < batch_size; ++n) {
-    const auto & img = resized_images[n];
-    const auto * src_ptr = img.data;
-    for (int h = 0; h < input_height_; ++h) {
-      for (int w = 0; w < input_width_; ++w) {
-        for (int c = 0; c < input_chan; ++c) {
-          const size_t offset_cv =
-            h * strides_cv[1] + w * strides_cv[2] + (input_chan - c - 1) * strides_cv[3];
-          const size_t offset =
-            n * strides[0] + c * strides[1] + h * strides[2] + w * strides[3];
-          const float value = static_cast<float>(src_ptr[offset_cv]) / 255.0f;
-          input_h_[offset] = (value - mean[c]) / std_vals[c];
-        }
-      }
+    cv::split(resized_images[n], src_planes);
+    for (int c = 0; c < input_chan; ++c) {
+      cv::Mat dst_plane(
+        input_height_, input_width_, CV_32F,
+        input_h_.data() + n * input_chan * plane + static_cast<size_t>(c) * plane);
+      src_planes[input_chan - 1 - c].convertTo(
+        dst_plane, CV_32F, 1.0 / (255.0 * std_vals[c]), -mean[c] / std_vals[c]);
     }
   }
 

--- a/depth_anything_v3/src/tensorrt_depth_anything/tensorrt_depth_anything.cpp
+++ b/depth_anything_v3/src/tensorrt_depth_anything/tensorrt_depth_anything.cpp
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include <algorithm>
-#include <array>
 #include <filesystem>
 #include <functional>
 #include <memory>
@@ -170,11 +169,9 @@ TensorRTDepthAnything::TensorRTDepthAnything(
     throw std::runtime_error("Expected TensorRT engine to expose 'sky' output tensor, but none was found");
   }
 
-  // Allocate GPU/CPU memory for outputs
+  // Allocate GPU memory for outputs
   depth_d_ = cuda_utils::make_unique<float[]>(depth_elem_num_);
-  depth_h_ = cuda_utils::make_unique_host<float[]>(depth_elem_num_, cudaHostAllocDefault);
   sky_d_ = cuda_utils::make_unique<float[]>(sky_elem_num_);
-  sky_h_ = cuda_utils::make_unique_host<float[]>(sky_elem_num_, cudaHostAllocDefault);
 
   // Get input dimensions
   const auto input_dims = trt_common_->getBindingDimensions(0);
@@ -201,6 +198,28 @@ void TensorRTDepthAnything::initPreprocessBuffer(int width, int height)
       image_size * batch_size_, cudaHostAllocDefault);
     image_buf_d_ = cuda_utils::make_unique<unsigned char[]>(image_size * batch_size_);
   }
+}
+
+void TensorRTDepthAnything::initPostprocessBuffers(
+  int width, int height, int out_width, int out_height)
+{
+  if (width == post_width_ && height == post_height_ &&
+    out_width == post_out_width_ && out_height == post_out_height_)
+  {
+    return;
+  }
+
+  const size_t plane_size = static_cast<size_t>(width) * height;
+  depth_scaled_d_ = cuda_utils::make_unique<float[]>(plane_size);
+  depth_full_d_ = cuda_utils::make_unique<float[]>(static_cast<size_t>(out_width) * out_height);
+  sky_mask_d_ = cuda_utils::make_unique<uint8_t[]>(plane_size);
+  post_scratch_bytes_ = postprocessScratchBytes(static_cast<int>(plane_size));
+  post_scratch_d_ = cuda_utils::make_unique<uint8_t[]>(post_scratch_bytes_);
+
+  post_width_ = width;
+  post_height_ = height;
+  post_out_width_ = out_width;
+  post_out_height_ = out_height;
 }
 
 bool TensorRTDepthAnything::doInference(
@@ -272,13 +291,11 @@ void TensorRTDepthAnything::preprocess(const std::vector<cv::Mat> & images)
       if (required_output_elems != depth_elem_num_) {
         depth_elem_num_ = required_output_elems;
         depth_d_ = cuda_utils::make_unique<float[]>(depth_elem_num_);
-        depth_h_ = cuda_utils::make_unique_host<float[]>(depth_elem_num_, cudaHostAllocDefault);
       }
     } else if (name && std::string(name) == "sky") {
       if (required_output_elems != sky_elem_num_) {
         sky_elem_num_ = required_output_elems;
         sky_d_ = cuda_utils::make_unique<float[]>(sky_elem_num_);
-        sky_h_ = cuda_utils::make_unique_host<float[]>(sky_elem_num_, cudaHostAllocDefault);
       }
     }
   }
@@ -305,7 +322,6 @@ bool TensorRTDepthAnything::infer()
     } else if (tensor_name == "sky" || tensor_name.find("sky") != std::string::npos) {
       if (!sky_d_ && sky_elem_num_ > 0) {
         sky_d_ = cuda_utils::make_unique<float[]>(sky_elem_num_);
-        sky_h_ = cuda_utils::make_unique_host<float[]>(sky_elem_num_, cudaHostAllocDefault);
       }
       buffer_ptr = sky_d_ ? static_cast<void *>(sky_d_.get()) : static_cast<void *>(depth_d_.get());
     } else {
@@ -322,16 +338,6 @@ bool TensorRTDepthAnything::infer()
     return false;
   }
 
-  CHECK_CUDA_ERROR(cudaMemcpyAsync(
-    depth_h_.get(), depth_d_.get(), depth_elem_num_ * sizeof(float),
-    cudaMemcpyDeviceToHost, *stream_));
-
-  if (sky_d_ && sky_h_) {
-    CHECK_CUDA_ERROR(cudaMemcpyAsync(
-      sky_h_.get(), sky_d_.get(), sky_elem_num_ * sizeof(float),
-      cudaMemcpyDeviceToHost, *stream_));
-  }
-
   CHECK_CUDA_ERROR(cudaStreamSynchronize(*stream_));
 
   return true;
@@ -344,94 +350,38 @@ void TensorRTDepthAnything::postprocess(
   const int height = output_dims.nbDims > 2 ? output_dims.d[2] : input_height_;
   const int width = output_dims.nbDims > 3 ? output_dims.d[3] : input_width_;
 
-  // Use depth output directly
-  const float * depth_ptr = depth_h_.get();
   const size_t plane_size = static_cast<size_t>(height) * width;
-  model_depth_.create(height, width, CV_32FC1);
-  std::memcpy(model_depth_.data, depth_ptr, plane_size * sizeof(float));
-
-  // Sky output
-  sky_mask_.release();
-  cv::Mat sky_pred(height, width, CV_32FC1, const_cast<float *>(sky_h_.get()));
-  sky_mask_ = sky_pred < sky_threshold_;
-
-
-  // Clean and scale to metric depth.
-  cv::Mat depth_map = model_depth_.clone();
-  depth_map.setTo(0.0f, depth_map <= 0.0f);
+  const size_t full_size = static_cast<size_t>(src_width_) * src_height_;
 
   // Use original intrinsics for metric conversion per spec.
   const double fx = camera_info.k[0] * scale_x_;
   const double fy = camera_info.k[4] * scale_y_;
   const double focal_pixels = 0.5 * (fx + fy);
   const double focal_scale = focal_pixels > 0.0 ? focal_pixels / 300.0 : 1.0;
-  depth_map *= static_cast<float>(focal_scale);
 
-  // Handle sky: set sky pixels to max depth derived from non-sky regions.
-  if (!sky_mask_.empty()) {
-    std::vector<float> valid_depths;
-    valid_depths.reserve(plane_size);
-    const uint8_t * mask_ptr = sky_mask_.ptr<uint8_t>(0);
-    const float * depth_ptr_flat = reinterpret_cast<const float *>(depth_map.data);
-    for (size_t idx = 0; idx < plane_size; ++idx) {
-      if (mask_ptr[idx]) {
-        const float val = depth_ptr_flat[idx];
-        if (std::isfinite(val) && val > 0.0f) {
-          valid_depths.push_back(val);
-        }
-      }
-    }
-    if (!valid_depths.empty()) {
-      // For 100k < size < 200k the step below is 1, so the sample is the first
-      // 100k valid pixels in row-major order rather than a subsample spread over
-      // the frame. The fill value is calibrated against that, so it is kept.
-      size_t sample_size = valid_depths.size();
-      const size_t max_sample = 100000;
-      if (sample_size > max_sample) {
-        const size_t step = sample_size / max_sample;
-        std::vector<float> sampled;
-        sampled.reserve(max_sample);
-        for (size_t i = 0; i < sample_size && sampled.size() < max_sample; i += step) {
-          sampled.push_back(valid_depths[i]);
-        }
-        valid_depths.swap(sampled);
-      }
-      // 99th percentile from a histogram rather than a full nth_element pass.
-      constexpr int kBins = 4096;
-      float lo = valid_depths[0], hi = valid_depths[0];
-      for (const float v : valid_depths) {
-        lo = std::min(lo, v);
-        hi = std::max(hi, v);
-      }
-      float max_depth;
-      if (hi <= lo) {
-        max_depth = std::min(lo, sky_depth_cap_);
-      } else {
-        std::array<uint32_t, kBins> hist{};
-        const float bin_scale = (kBins - 1) / (hi - lo);
-        for (const float v : valid_depths) {
-          ++hist[static_cast<int>((v - lo) * bin_scale)];
-        }
-        const size_t target = static_cast<size_t>(0.99 * (valid_depths.size() - 1));
-        size_t cumulative = 0;
-        int bin = 0;
-        for (; bin < kBins; ++bin) {
-          cumulative += hist[bin];
-          if (cumulative > target) break;
-        }
-        max_depth = std::min(lo + static_cast<float>(bin) / bin_scale, sky_depth_cap_);
-      }
-      cv::Mat depth_map_reshaped(height, width, CV_32FC1, depth_map.data);
-      depth_map_reshaped.setTo(max_depth, ~sky_mask_);
-    }
-  }
+  // Scaling, the sky mask, the sky fill and the upscale to camera resolution all
+  // run on the depth map the engine produced; only the published results are
+  // copied back.
+  initPostprocessBuffers(width, height, src_width_, src_height_);
+  launchPostprocess(
+    depth_d_.get(), sky_d_.get(), width, height,
+    static_cast<float>(focal_scale), sky_threshold_, sky_depth_cap_,
+    src_width_, src_height_,
+    depth_scaled_d_.get(), sky_mask_d_.get(), depth_full_d_.get(),
+    post_scratch_d_.get(), post_scratch_bytes_, *stream_);
 
-  // Persist scaled depth for point cloud generation at network resolution.
-  model_depth_ = depth_map.clone();
-
-
-  cv::resize(model_depth_, depth_image_, cv::Size(src_width_, src_height_), 0, 0, cv::INTER_CUBIC);
-
+  model_depth_.create(height, width, CV_32FC1);
+  sky_mask_.create(height, width, CV_8UC1);
+  depth_image_.create(src_height_, src_width_, CV_32FC1);
+  CHECK_CUDA_ERROR(cudaMemcpyAsync(
+    model_depth_.data, depth_scaled_d_.get(), plane_size * sizeof(float),
+    cudaMemcpyDeviceToHost, *stream_));
+  CHECK_CUDA_ERROR(cudaMemcpyAsync(
+    sky_mask_.data, sky_mask_d_.get(), plane_size, cudaMemcpyDeviceToHost, *stream_));
+  CHECK_CUDA_ERROR(cudaMemcpyAsync(
+    depth_image_.data, depth_full_d_.get(), full_size * sizeof(float),
+    cudaMemcpyDeviceToHost, *stream_));
+  CHECK_CUDA_ERROR(cudaStreamSynchronize(*stream_));
 
   cv::Mat colorized = rgb_image;
   if (!colorized.empty() &&

--- a/depth_anything_v3/src/tensorrt_depth_anything/tensorrt_depth_anything.cpp
+++ b/depth_anything_v3/src/tensorrt_depth_anything/tensorrt_depth_anything.cpp
@@ -338,8 +338,6 @@ bool TensorRTDepthAnything::infer()
     return false;
   }
 
-  CHECK_CUDA_ERROR(cudaStreamSynchronize(*stream_));
-
   return true;
 }
 
@@ -402,7 +400,7 @@ void TensorRTDepthAnything::buildPointCloud(
   cv::Mat color;
   if (!rgb_image.empty()) {
     if (rgb_image.type() == CV_8UC3) {
-      color = rgb_image.clone();
+      color = rgb_image;
     } else {
       rgb_image.convertTo(color, CV_8UC3);
     }

--- a/depth_anything_v3/src/tensorrt_depth_anything/tensorrt_depth_anything.cpp
+++ b/depth_anything_v3/src/tensorrt_depth_anything/tensorrt_depth_anything.cpp
@@ -377,12 +377,6 @@ void TensorRTDepthAnything::postprocess(
   cv::Mat sky_pred(height, width, CV_32FC1, const_cast<float *>(sky_h_.get()));
   sky_mask_ = sky_pred < sky_threshold_;
 
-  // Inspect raw output before scaling.
-  double raw_min = 0.0, raw_max = 0.0;
-  cv::minMaxLoc(model_depth_, &raw_min, &raw_max);
-  RCLCPP_DEBUG(
-    rclcpp::get_logger("TensorRTDepthAnything"),
-    "Raw net output min/max: %.6f / %.6f", raw_min, raw_max);
 
   // Clean and scale to metric depth.
   cv::Mat depth_map = model_depth_.clone();
@@ -432,14 +426,6 @@ void TensorRTDepthAnything::postprocess(
   // Persist scaled depth for point cloud generation at network resolution.
   model_depth_ = depth_map.clone();
 
-  double min_metric = 0.0, max_metric = 0.0;
-  cv::minMaxLoc(model_depth_, &min_metric, &max_metric);
-  RCLCPP_DEBUG(
-    rclcpp::get_logger("TensorRTDepthAnything"),
-    "Metric depth (model) min/max: %.6f / %.6f meters", min_metric, max_metric);
-  RCLCPP_DEBUG(
-    rclcpp::get_logger("TensorRTDepthAnything"),
-    "Focal length in pixels: %.6f (scale factor: %.6f)", focal_pixels, focal_scale);
 
   cv::resize(model_depth_, depth_image_, cv::Size(src_width_, src_height_), 0, 0, cv::INTER_CUBIC);
 

--- a/depth_anything_v3/src/tensorrt_depth_anything/tensorrt_depth_anything.cpp
+++ b/depth_anything_v3/src/tensorrt_depth_anything/tensorrt_depth_anything.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <algorithm>
+#include <array>
 #include <filesystem>
 #include <functional>
 #include <memory>
@@ -404,6 +405,9 @@ void TensorRTDepthAnything::postprocess(
       }
     }
     if (!valid_depths.empty()) {
+      // For 100k < size < 200k the step below is 1, so the sample is the first
+      // 100k valid pixels in row-major order rather than a subsample spread over
+      // the frame. The fill value is calibrated against that, so it is kept.
       size_t sample_size = valid_depths.size();
       const size_t max_sample = 100000;
       if (sample_size > max_sample) {
@@ -415,9 +419,31 @@ void TensorRTDepthAnything::postprocess(
         }
         valid_depths.swap(sampled);
       }
-      const size_t idx = static_cast<size_t>(0.99 * (valid_depths.size() - 1));
-      std::nth_element(valid_depths.begin(), valid_depths.begin() + idx, valid_depths.end());
-      const float max_depth = std::min(valid_depths[idx], sky_depth_cap_);
+      // 99th percentile from a histogram rather than a full nth_element pass.
+      constexpr int kBins = 4096;
+      float lo = valid_depths[0], hi = valid_depths[0];
+      for (const float v : valid_depths) {
+        lo = std::min(lo, v);
+        hi = std::max(hi, v);
+      }
+      float max_depth;
+      if (hi <= lo) {
+        max_depth = std::min(lo, sky_depth_cap_);
+      } else {
+        std::array<uint32_t, kBins> hist{};
+        const float bin_scale = (kBins - 1) / (hi - lo);
+        for (const float v : valid_depths) {
+          ++hist[static_cast<int>((v - lo) * bin_scale)];
+        }
+        const size_t target = static_cast<size_t>(0.99 * (valid_depths.size() - 1));
+        size_t cumulative = 0;
+        int bin = 0;
+        for (; bin < kBins; ++bin) {
+          cumulative += hist[bin];
+          if (cumulative > target) break;
+        }
+        max_depth = std::min(lo + static_cast<float>(bin) / bin_scale, sky_depth_cap_);
+      }
       cv::Mat depth_map_reshaped(height, width, CV_32FC1, depth_map.data);
       depth_map_reshaped.setTo(max_depth, ~sky_mask_);
     }

--- a/depth_anything_v3/src/tensorrt_depth_anything/tensorrt_depth_anything.cpp
+++ b/depth_anything_v3/src/tensorrt_depth_anything/tensorrt_depth_anything.cpp
@@ -271,13 +271,15 @@ void TensorRTDepthAnything::preprocess(const std::vector<cv::Mat> & images)
   // Upload the frame and let one kernel write the normalised NCHW tensor
   // straight into the engine's input buffer.
   const cv::Mat & src_image = images[0];
-  const size_t src_bytes = static_cast<size_t>(src_image.cols) * src_image.rows * 3;
+  const size_t row_bytes = static_cast<size_t>(src_image.cols) * 3;
+  const size_t src_bytes = row_bytes * src_image.rows;
   if (!image_buf_d_ || src_bytes != image_buf_bytes_) {
     image_buf_d_ = cuda_utils::make_unique<unsigned char[]>(src_bytes);
     image_buf_bytes_ = src_bytes;
   }
-  CHECK_CUDA_ERROR(cudaMemcpyAsync(
-    image_buf_d_.get(), src_image.data, src_bytes, cudaMemcpyHostToDevice, *stream_));
+  CHECK_CUDA_ERROR(cudaMemcpy2DAsync(
+    image_buf_d_.get(), row_bytes, src_image.data, src_image.step,
+    row_bytes, src_image.rows, cudaMemcpyHostToDevice, *stream_));
   launchPreprocess(
     image_buf_d_.get(), src_image.cols, src_image.rows,
     input_d_.get(), input_width_, input_height_, *stream_);

--- a/depth_anything_v3/src/tensorrt_depth_anything/tensorrt_depth_anything.cpp
+++ b/depth_anything_v3/src/tensorrt_depth_anything/tensorrt_depth_anything.cpp
@@ -185,7 +185,6 @@ TensorRTDepthAnything::TensorRTDepthAnything(
   // Allocate input memory
   const size_t input_elem_num = batch_size_ * input_channels * input_height_ * input_width_;
   input_d_ = cuda_utils::make_unique<float[]>(input_elem_num);
-  input_h_.resize(input_elem_num);
 
 }
 
@@ -222,7 +221,7 @@ bool TensorRTDepthAnything::doInference(
     return false;
   }
 
-  // Preprocess (GPU preprocessing not yet implemented, using CPU)
+  // Preprocess
   preprocess(images);
 
   // Run inference
@@ -239,7 +238,6 @@ bool TensorRTDepthAnything::doInference(
 
 void TensorRTDepthAnything::preprocess(const std::vector<cv::Mat> & images)
 {
-  const auto batch_size = images.size();
   auto input_dims = trt_common_->getBindingDimensions(0);
   if (input_dims.d[0] == -1) {
     input_dims.d[0] = batch_size_;
@@ -248,39 +246,22 @@ void TensorRTDepthAnything::preprocess(const std::vector<cv::Mat> & images)
 
   input_height_ = input_dims.d[2];
   input_width_ = input_dims.d[3];
-  const int input_chan = input_dims.d[1];
   scale_x_ = static_cast<double>(input_width_) / static_cast<double>(src_width_);
   scale_y_ = static_cast<double>(input_height_) / static_cast<double>(src_height_);
 
-
-  std::vector<cv::Mat> resized_images;
-  resized_images.reserve(batch_size);
-  for (const auto & image : images) {
-    cv::Mat resized_image;
-    cv::resize(image, resized_image, cv::Size(input_width_, input_height_), 0, 0, cv::INTER_CUBIC);
-    resized_images.emplace_back(resized_image);
+  // Upload the frame and let one kernel write the normalised NCHW tensor
+  // straight into the engine's input buffer.
+  const cv::Mat & src_image = images[0];
+  const size_t src_bytes = static_cast<size_t>(src_image.cols) * src_image.rows * 3;
+  if (!image_buf_d_ || src_bytes != image_buf_bytes_) {
+    image_buf_d_ = cuda_utils::make_unique<unsigned char[]>(src_bytes);
+    image_buf_bytes_ = src_bytes;
   }
-
-  const size_t volume = batch_size * input_chan * input_height_ * input_width_;
-  input_h_.resize(volume);
-
-  const float mean[3] = {0.485f, 0.456f, 0.406f};
-  const float std_vals[3] = {0.229f, 0.224f, 0.225f};
-
-  // (v/255 - mean) / std  folded into convertTo's alpha/beta, per plane.
-  // cv::split gives B,G,R so destination channel c reads plane (chan-1-c).
-  const size_t plane = static_cast<size_t>(input_height_) * input_width_;
-  std::vector<cv::Mat> src_planes;
-  for (size_t n = 0; n < batch_size; ++n) {
-    cv::split(resized_images[n], src_planes);
-    for (int c = 0; c < input_chan; ++c) {
-      cv::Mat dst_plane(
-        input_height_, input_width_, CV_32F,
-        input_h_.data() + n * input_chan * plane + static_cast<size_t>(c) * plane);
-      src_planes[input_chan - 1 - c].convertTo(
-        dst_plane, CV_32F, 1.0 / (255.0 * std_vals[c]), -mean[c] / std_vals[c]);
-    }
-  }
+  CHECK_CUDA_ERROR(cudaMemcpyAsync(
+    image_buf_d_.get(), src_image.data, src_bytes, cudaMemcpyHostToDevice, *stream_));
+  launchPreprocess(
+    image_buf_d_.get(), src_image.cols, src_image.rows,
+    input_d_.get(), input_width_, input_height_, *stream_);
 
   auto * engine = trt_common_->getEngine();
   for (int i = 0; i < trt_common_->getNbIOTensors(); ++i) {
@@ -301,10 +282,6 @@ void TensorRTDepthAnything::preprocess(const std::vector<cv::Mat> & images)
       }
     }
   }
-
-  CHECK_CUDA_ERROR(cudaMemcpyAsync(
-    input_d_.get(), input_h_.data(), input_h_.size() * sizeof(float), cudaMemcpyHostToDevice,
-    *stream_));
 }
 
 bool TensorRTDepthAnything::infer()


### PR DESCRIPTION
## Summary

Reduces per-frame CPU work in the inference path, mostly by moving preprocessing and postprocessing onto the GPU instead of copying the depth map back to the host to process it with OpenCV.

On the test bag the node goes from 56.9 to 73.5 FPS, a 22.5% drop in per-frame latency.

No new dependencies. CUDA is already required by the package, and CUB ships with the CUDA toolkit. Parameters, topics, launch arguments and the ONNX contract are unchanged.

Measured on Ubuntu 24.04 with an RTX 4080 Laptop (sm_89) and an i9-14900HX, running TensorRT 10.13, CUDA 13.0, OpenCV 4.6, ROS 2 Jazzy and `rmw_zenoh_cpp`.

## Changes

The first three commits optimise this work on the CPU, and commits 5 and 6 then replace most of that code with CUDA kernels.

| # | Commit | Effect |
|---|---|---|
| 1 | Vectorise preprocessing normalisation with split + convertTo | 632 to 78 us per frame |
| 2 | Drop two minMaxLoc scans that only feed disabled debug logs | 96 us per frame |
| 3 | Use a histogram for the sky fill percentile instead of nth_element | 768 to 260 us per frame |
| 4 | Decode each frame once instead of twice | 1.58 ms per frame |
| 5 | Run preprocessing on the GPU in a single kernel | 1119 to 165 us per frame |
| 6 | Run postprocessing on the GPU | 1.00 ms per frame |
| 7 | Drop two redundant frame copies and an extra stream sync | 0.09 ms per frame |

### Duplicate decoding

`sub_image_` and `debug_image_sub_` were two independent image_transport subscriptions on the same topic, so every compressed frame was decoded twice. The second one existed only to count arrivals. Registering that callback on the existing subscriber decodes once and keeps the diagnostic, including its ability to spot images that arrive but fail to synchronise with camera_info.

### Resize filter

The preprocessing kernel reimplements OpenCV's `INTER_CUBIC` rather than substituting bilinear. Bilinear is cheaper but moves the published depth by up to 85 m, measured end to end. The kernel agrees with `cv::resize` to under one grey level.

### Percentile on the device

Postprocessing keeps the depth map on the GPU from the moment the engine produces it. A CUB exclusive scan supplies the pixel rank, so the existing sampling behaviour is reproduced exactly.

## Testing

- KITTI raw drive 0009 converted to a rosbag: 447 frames at 1242x375, published as compressed images with camera_info.
- Replayed at 12x real time (about 116 Hz) so the node, not the playback, is the bottleneck.
- Each comparison alternates between a build of `main` and a build of this branch inside a single run, four rounds of 800 frame intervals per side. Alternating matters because drift between separate runs is around 5%, larger than several of the individual commits.
- `enable_debug` forced false on both sides. It is a config default worth about 7% that helps `main` equally, so leaving it on would flatter the result. The shipped default is untouched.
- Each optimisation was benchmarked in isolation first, with the baseline copied verbatim from the package source.
- Output from both builds compared frame by frame, matched on header stamp.

## Results

| | main | this branch |
|---|---|---|
| median frame time | 17.567 ms | 13.615 ms |
| throughput | 56.93 FPS | 73.45 FPS |

Difference: 3.952 ms, or 22.5% lower latency. Repeating the measurement puts the figure between 22.05% and 22.96%, so it is well clear of run-to-run noise. As throughput that is a 29% increase.

Per-frame CPU time drops by about 35%, and `libopencv_imgproc` falls from around 35% of process cycles to around 10%.

## Not done

The callback still blocks while the engine runs, so none of the remaining host work overlaps with inference. Overlapping the two looks like the largest remaining win, but I have not implemented or measured it.
